### PR TITLE
Add release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Build
         run: make build
         env:
-          PROVAZIO_REPOSITORY: ${{ env.RELEASE_REGISTRY }}/${{ env.RELEASE_REPO }}/
+          REGISTRY: ${{ env.RELEASE_REGISTRY }}/${{ env.RELEASE_REPO }}/
 
       - name: Push images
         run: make push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+  # Create unstable release on push to development
+  push:
+    branches:
+      - development
+
+env:
+  RELEASE_REGISTRY: gcr.io
+  RELEASE_REPO: iguazio
+
+jobs:
+  release-preperation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Delete previous unstable release
+        if: github.event_name == 'push'
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true # default: false
+          tag_name: unstable # tag name to delete
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create new unstable release
+        id: create_unstable_release
+        if: github.event_name == 'push'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: unstable
+          release_name: unstable
+          body: |
+            Latest unstable release
+            - Git sha ${{ github.sha }}
+            - Updated at ${{ github.event.head_commit.timestamp }}
+          draft: false
+          prerelease: false
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ release-preperation ]
+    steps:
+      - name: Dump github context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Dump runner context
+        run: echo "$RUNNER_CONTEXT"
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+
+      - name: Dump github ref
+        run: echo "$GITHUB_REF"
+
+      - name: Extract ref info
+        id: release_info
+        run: |
+          echo ::set-output name=REF_BRANCH::${GITHUB_REF#refs/heads/}
+          echo ::set-output name=REF_TAG::${GITHUB_REF#refs/tags/}
+
+      - name: Set Version tag to unstable
+        if: github.event_name == 'push' && steps.release_info.outputs.REF_BRANCH == 'development'
+        run: |
+          echo "VERSION=unstable" >> $GITHUB_ENV
+
+      # the image tag convention is semver without the v prefix
+      - name: Set Version to release tag
+        if: github.event_name == 'release'
+        run: |
+          version=${{ steps.release_info.outputs.REF_TAG }}
+          version=${version#"v"}
+          echo "VERSION=${version}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+
+      - name: Login to GCR
+        run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin https://gcr.io
+        env:
+          GCR_JSON_KEY: ${{ secrets.GCR_IGUAZIO_JSON_KEY }}
+
+      - name: Build
+        run: make build
+        env:
+          PROVAZIO_REPOSITORY: ${{ env.RELEASE_REGISTRY }}/${{ env.RELEASE_REPO }}/
+
+      - name: Push images
+        run: make push
+        env:
+          REGISTRY: ${{ env.RELEASE_REGISTRY }}/${{ env.RELEASE_REPO }}/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ VERSION ?= "unstable"
 GOPATH ?= $(shell go env GOPATH)
 OS_NAME = $(shell uname)
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
-REGISTRY_HANDLER_IMAGE_NAME ?= "gcr.io/iguazio/registry-creds-handler:$(VERSION)"
+REGISTRY ?= "gcr.io/iguazio/"
+REGISTRY_HANDLER_IMAGE_NAME ?= "$(REGISTRY)registry-creds-handler:$(VERSION)"
 
 # Link flags
 GO_LINK_FLAGS ?= -s -w
@@ -12,11 +13,19 @@ GO_LINK_FLAGS_INJECT_VERSION := $(GO_LINK_FLAGS) \
 
 .PHONY: build
 build:
+	@echo "Building image"
 	docker build \
 		--build-arg GO_LINK_FLAGS="$(GO_LINK_FLAGS_INJECT_VERSION)" \
 		--file cmd/registrycredshandler/Dockerfile \
 		--tag $(REGISTRY_HANDLER_IMAGE_NAME) \
 		.
+	@echo "Done"
+
+.PHONY: push
+push:
+	@echo "Pushing image"
+	docker push $(REGISTRY_HANDLER_IMAGE_NAME)
+	@echo "Done"
 
 .PHONY: fmt
 fmt:

--- a/cmd/registrycredshandler/Dockerfile
+++ b/cmd/registrycredshandler/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:alpine as builder
 
-ARG VERSION_LABEL=unstable
-
 ARG GO_LINK_FLAGS="-s -w"
 
 ARG GOOS=linux
@@ -13,7 +11,12 @@ WORKDIR /app
 COPY . .
 
 RUN apk add -U --no-cache ca-certificates
-RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -a -installsuffix cgo -ldflags="${GO_LINK_FLAGS}"  -o registrycredshandler cmd/registrycredshandler/main.go
+
+RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build \
+    -a \
+    -installsuffix cgo \
+    -ldflags="${GO_LINK_FLAGS}"  \
+    -o registrycredshandler cmd/registrycredshandler/main.go
 
 FROM scratch
 

--- a/cmd/registrycredshandler/main.go
+++ b/cmd/registrycredshandler/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -24,13 +25,14 @@ func run() error {
 	refreshRate := flag.Int64("refresh-rate", 60, "Refresh credentials rate in min (Default: 60 minutes)")
 	kubeConfigPath := flag.String("kubeconfig-path", "", "Kubernetes config path, If not specified uses in cluster config")
 	creds := flag.String("creds", "", "Credentials to retrieve registry authorization token in JSON format, entries must be in lowerCamelCase")
-	showVersion := flag.Bool("version", false, "Show version and exit")
+	showVersion := flag.Bool("version", false, "Show version in j and exit")
 	logsFormat := flag.String("logs-format", "humanreadable", "Logging format (json|humanreadable) (Default: humanreadable)")
 
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("%#v", version.Get())
+		encodedVersionInfo, _ := json.Marshal(version.Get())
+		fmt.Printf(string(encodedVersionInfo))
 		return nil
 	}
 

--- a/cmd/registrycredshandler/main.go
+++ b/cmd/registrycredshandler/main.go
@@ -32,7 +32,7 @@ func run() error {
 
 	if *showVersion {
 		encodedVersionInfo, _ := json.Marshal(version.Get())
-		fmt.Printf(string(encodedVersionInfo))
+		fmt.Print(string(encodedVersionInfo))
 		return nil
 	}
 


### PR DESCRIPTION
Release flow - determine tag, build image and push to pre-defined registry
tag is determined by - if release - use release tag, if push to development - use `unstable`.
either way, omit `v` from the release `v1.2.3` -> `1.2.3`