### PR TITLE
k8s - add username and password to secret and decode base64 creds

### DIFF
--- a/cmd/registrycredshandler/main.go
+++ b/cmd/registrycredshandler/main.go
@@ -24,7 +24,8 @@ func run() error {
 	registryUri := flag.String("registry-uri", "", "Registry URI to use for authentication")
 	refreshRate := flag.Int64("refresh-rate", 60, "Refresh credentials rate in min (Default: 60 minutes)")
 	kubeConfigPath := flag.String("kubeconfig-path", "", "Kubernetes config path, If not specified uses in cluster config")
-	creds := flag.String("creds", "", "Credentials to retrieve registry authorization token in JSON format, entries must be in lowerCamelCase")
+	creds := flag.String("creds", "",
+		"Credentials to retrieve registry authorization token in JSON format and base64 encoded, entries must be in lowerCamelCase")
 	showVersion := flag.Bool("version", false, "Show version in j and exit")
 	logsFormat := flag.String("logs-format", "humanreadable", "Logging format (json|humanreadable) (Default: humanreadable)")
 

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -19,7 +19,9 @@ type DockerConfigJSON struct {
 }
 
 type RegistryAuth struct {
-	Auth string `json:"auth"`
+	Auth     string `json:"auth"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 func GetClientConfig(kubeConfigPath string) (*rest.Config, error) {
@@ -115,9 +117,16 @@ func CompileRegistryAuthSecret(token *registry.Token) (*v1.Secret, error) {
 		Type: "kubernetes.io/dockerconfigjson",
 	}
 
+	username, password, err := ParseAuth(token.Auth)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse auth")
+	}
+
 	auths := map[string]RegistryAuth{}
 	auths[token.RegistryUri] = RegistryAuth{
-		Auth: token.Auth,
+		Auth:     token.Auth,
+		Username: username,
+		Password: password,
 	}
 
 	configJSON, err := json.Marshal(DockerConfigJSON{Auths: auths})

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -1,5 +1,12 @@
 package common
 
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/nuclio/errors"
+)
+
 func GetFirstNonEmptyString(strings []string) string {
 	for _, s := range strings {
 		if s != "" {
@@ -7,4 +14,19 @@ func GetFirstNonEmptyString(strings []string) string {
 		}
 	}
 	return ""
+}
+
+func ParseAuth(auth string) (string, string, error) {
+	decodedAuth, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to decode auth")
+	}
+
+	splitAuth := strings.Split(string(decodedAuth), ":")
+	if len(splitAuth) < 2 {
+		return "", "", errors.Wrap(err, "Failed to split auth")
+	}
+
+	// username, password
+	return splitAuth[0], splitAuth[1], nil
 }

--- a/pkg/registry/abstract/registry.go
+++ b/pkg/registry/abstract/registry.go
@@ -12,7 +12,7 @@ type Registry struct {
 	registry    registry.Registry
 	SecretName  string
 	Namespace   string
-	Creds       string
+	Creds       []byte
 	RegistryUri string
 }
 
@@ -20,7 +20,7 @@ func NewRegistry(loggerInstance logger.Logger,
 	registry registry.Registry,
 	secretName string,
 	namespace string,
-	creds string,
+	creds []byte,
 	registryUri string) (*Registry, error) {
 	abstractRegistry := &Registry{
 		Logger:      loggerInstance.GetChild("registry"),

--- a/pkg/registry/ecr/registry.go
+++ b/pkg/registry/ecr/registry.go
@@ -27,7 +27,7 @@ type Registry struct {
 func NewRegistry(parentLogger logger.Logger,
 	secretName string,
 	namespace string,
-	creds string,
+	creds []byte,
 	registryUri string) (*Registry, error) {
 	newRegistry := &Registry{}
 
@@ -63,7 +63,7 @@ func (r *Registry) enrich() error {
 
 	// parse aws credentials
 	var awsCreds registry.AWSCreds
-	if err := json.Unmarshal([]byte(r.Creds), &awsCreds); err != nil {
+	if err := json.Unmarshal(r.Creds, &awsCreds); err != nil {
 		r.Logger.WarnWith("Failed to parse json AWS credentials, checking env", "err", err.Error())
 	}
 

--- a/pkg/registry/factory/factory.go
+++ b/pkg/registry/factory/factory.go
@@ -20,7 +20,7 @@ func CreateRegistry(parentLogger logger.Logger,
 	var err error
 
 	switch registryKind {
-	case registry.ECRRegistryKind:
+	case string(registry.ECRRegistryKind):
 		newRegistry, err = ecr.NewRegistry(parentLogger,
 			secretName,
 			namespace,

--- a/pkg/registry/factory/factory.go
+++ b/pkg/registry/factory/factory.go
@@ -1,6 +1,8 @@
 package factory
 
 import (
+	"encoding/base64"
+
 	"github.com/v3io/registry-creds-handler/pkg/registry"
 	"github.com/v3io/registry-creds-handler/pkg/registry/ecr"
 
@@ -19,12 +21,17 @@ func CreateRegistry(parentLogger logger.Logger,
 	var newRegistry registry.Registry
 	var err error
 
+	encodedCreds, err := base64.StdEncoding.DecodeString(creds)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode creds")
+	}
+
 	switch registryKind {
 	case string(registry.ECRRegistryKind):
 		newRegistry, err = ecr.NewRegistry(parentLogger,
 			secretName,
 			namespace,
-			creds,
+			encodedCreds,
 			registryUri)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create ECR kind")

--- a/pkg/registry/mock/registry.go
+++ b/pkg/registry/mock/registry.go
@@ -19,7 +19,7 @@ type Registry struct {
 func NewRegistry(parentLogger logger.Logger,
 	secretName string,
 	namespace string,
-	creds string,
+	creds []byte,
 	registryUri string) (*Registry, error) {
 	newRegistry := &Registry{}
 

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -1,7 +1,9 @@
 package registry
 
+type DockerRegistryKind string
+
 const (
-	ECRRegistryKind string = "ecr"
+	ECRRegistryKind DockerRegistryKind = "ecr"
 )
 
 type Token struct {

--- a/pkg/registrycredshandler/registrycredshandler_test.go
+++ b/pkg/registrycredshandler/registrycredshandler_test.go
@@ -20,7 +20,7 @@ type HandlerSuite struct {
 
 func (suite *HandlerSuite) TestCreateOrUpdateSecretSanity() {
 	loggerInstance, _ := common.CreateLogger("test", true, os.Stdout, "humanreadable")
-	mockedRegistry, _ := mock.NewRegistry(loggerInstance, "secret name", "some namespace", "", "")
+	mockedRegistry, _ := mock.NewRegistry(loggerInstance, "secret name", "some namespace", []byte{}, "")
 	mockedKubeClientSet := fake.NewSimpleClientset()
 	handler, err := NewHandler(loggerInstance, mockedKubeClientSet, mockedRegistry, 0, "mock")
 	suite.Require().NoError(err)
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) TestCreateOrUpdateSecretSanity() {
 
 func (suite *HandlerSuite) TestRefreshingSecretSanity() {
 	loggerInstance, _ := common.CreateLogger("test", true, os.Stdout, "humanreadable")
-	mockedRegistry, _ := mock.NewRegistry(loggerInstance, "secret name", "some namespace", "", "")
+	mockedRegistry, _ := mock.NewRegistry(loggerInstance, "secret name", "some namespace", []byte{}, "")
 	mockedKubeClientSet := fake.NewSimpleClientset()
 	handler, err := NewHandler(loggerInstance, mockedKubeClientSet, mockedRegistry, 10, "mock")
 	suite.Require().NoError(err)


### PR DESCRIPTION
nuclio is extracting username and password from secret in order to perform docker login.
Even though `auth` has all the information needed, it is safer to add username and password to avoid such problems in the future.